### PR TITLE
Recommend `--preserve-env` argument to `sudo`

### DIFF
--- a/tool/diffprof/notes.txt
+++ b/tool/diffprof/notes.txt
@@ -1,6 +1,6 @@
 % brew install rbspy
 
-% sudo rbspy record --raw-file demo-mri ruby tool/diffprof/demo.rb
+% sudo --preserve-env rbspy record --raw-file demo-mri ruby tool/diffprof/demo.rb
 
 % jt --use jvm ruby --cpusampler --cpusampler.Mode=roots --cpusampler.Output=json --cpusampler.OutputFile=demo-tr tool/diffprof/demo.rb
 


### PR DESCRIPTION
It’s not necessary for `demo.rb` itself, but in general it’s useful to preserve the original user’s environment so that gems can still be loaded (e.g. when running benchmarks).