### PR TITLE
Remove JSON nesting depth limit for diffprof

### DIFF
--- a/tool/diffprof/tool.rb
+++ b/tool/diffprof/tool.rb
@@ -124,7 +124,7 @@ def match_activation(sample, activation)
   end
 end
 
-JSON.parse(File.read(tr_filename))['profile'].each do |thread|
+JSON.parse(File.read(tr_filename), max_nesting: false)['profile'].each do |thread|
   next unless thread['thread'].start_with?('Thread[main,')
   sample = thread['samples'].first
   match_activation sample, main_activation


### PR DESCRIPTION
The TruffleRuby CPU sampler output can be as deeply nested as the call stack (`profile.samples.children.children.children.children.children…`) so the resulting JSON document may be very deep, but `JSON.parse` has a [default maximum nesting depth](https://github.com/ruby/ruby/blob/v3_0_1/ext/json/parser/parser.c#L1805) of 100 which is easily exceeded in practice.

I don’t know what a reasonable maximum depth is, so I’ve bumped it up by an order of magnitude for now so we can see if that’s either sufficient or problematic.