### PR TITLE
Set `JT_ENV` to use `truffleruby-jvm-ce` by default

### DIFF
--- a/.spin/bin/env
+++ b/.spin/bin/env
@@ -3,6 +3,7 @@
 SCRIPT_PATH=$(dirname "$0")
 SCRIPT_PATH=$(cd "$SCRIPT_PATH" && pwd)
 TRUFFLERUBY_DIR=$SCRIPT_PATH/../..
+export JT_ENV=jvm-ce
 
 unset JAVA_HOME
 


### PR DESCRIPTION
A [recent change](https://github.com/oracle/truffleruby/commit/3e6908c5d06e9d4ef24380e429db0d9482cbd0a7) to TruffleRuby means that the `JT_ENV` environment variable will be respected by both `jt build` and `jt ruby` as the default value of their `--env` and `--use` flags respectively. `jvm-ce` is what we normally want to use in development so it’s convenient for it to be our Spin default.

I’ve used [`export`](https://www.gnu.org/software/bash/manual/bash.html#index-export) to set this environment variable so that its value is inherited by any child processes of the login shell (e.g. shell scripts, subshells) because that’s probably the behaviour that we want.

I’m opening this PR in our TruffleRuby fork so we can try it out first; if we agree it’s an improvement, I’ll upstream it.