### PR TITLE
Log the percentage of optimizable keyword argument methods

### DIFF
--- a/src/main/java/org/truffleruby/RubyContext.java
+++ b/src/main/java/org/truffleruby/RubyContext.java
@@ -22,6 +22,7 @@ import java.util.Map;
 import java.util.WeakHashMap;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.logging.Level;
 
@@ -52,6 +53,7 @@ import org.truffleruby.core.hash.ReHashable;
 import org.truffleruby.core.inlined.CoreMethods;
 import org.truffleruby.core.kernel.AtExitManager;
 import org.truffleruby.core.kernel.TraceManager;
+import org.truffleruby.core.method.RubyMethod;
 import org.truffleruby.core.module.RubyModule;
 import org.truffleruby.core.objectspace.ObjectSpaceManager;
 import org.truffleruby.core.proc.ProcOperations;
@@ -74,6 +76,7 @@ import org.truffleruby.language.dispatch.DispatchNode;
 import org.truffleruby.language.globals.GlobalVariableStorage;
 import org.truffleruby.language.loader.CodeLoader;
 import org.truffleruby.language.loader.FeatureLoader;
+import org.truffleruby.language.methods.InternalMethod;
 import org.truffleruby.language.objects.shared.SharedObjects;
 import org.truffleruby.options.LanguageOptions;
 import org.truffleruby.options.Options;
@@ -528,6 +531,11 @@ public class RubyContext {
             RubyLanguage.LOGGER.info(
                     "Total VALUE object to native conversions: " + getValueWrapperManager().totalHandleAllocations());
         }
+
+        RubyLanguage.LOGGER.info("Optimizable dynamic keyword arg calls: " + InternalMethod.optimizableCallCounter.get());
+        RubyLanguage.LOGGER.info("Total dynamic keyword arg calls: " + InternalMethod.dynamicCallCounter.get());
+        final int percentOptimizable = (InternalMethod.optimizableCallCounter.intValue() * 100) / InternalMethod.dynamicCallCounter.intValue();
+        RubyLanguage.LOGGER.info("Percent Optimizable: " + percentOptimizable + "%");
     }
 
     public boolean isPreInitializing() {

--- a/src/main/java/org/truffleruby/RubyContext.java
+++ b/src/main/java/org/truffleruby/RubyContext.java
@@ -532,10 +532,17 @@ public class RubyContext {
                     "Total VALUE object to native conversions: " + getValueWrapperManager().totalHandleAllocations());
         }
 
-        RubyLanguage.LOGGER.info("Optimizable dynamic keyword arg calls: " + InternalMethod.optimizableCallCounter.get());
-        RubyLanguage.LOGGER.info("Total dynamic keyword arg calls: " + InternalMethod.dynamicCallCounter.get());
-        final int percentOptimizable = (InternalMethod.optimizableCallCounter.intValue() * 100) / InternalMethod.dynamicCallCounter.intValue();
-        RubyLanguage.LOGGER.info("Percent Optimizable: " + percentOptimizable + "%");
+        RubyLanguage.LOGGER.info("Optimizable method calls: " + InternalMethod.optimizableMethodCallCounter.get());
+        RubyLanguage.LOGGER.info("Method calls with keyword arguments: " + InternalMethod.dynamicKeywordArgumentMethodCallCounter.get());
+        RubyLanguage.LOGGER.info("Total method calls: " + InternalMethod.dynamicMethodCallCounter.get());
+
+        final int percentMethodCallsWithKwArgsOptimizable = (InternalMethod.optimizableMethodCallCounter.intValue() * 100) /
+                InternalMethod.dynamicKeywordArgumentMethodCallCounter.intValue();
+        final int percentMethodCallsOptimizable = (InternalMethod.optimizableMethodCallCounter.intValue() * 100) /
+                InternalMethod.dynamicMethodCallCounter.intValue();
+
+        RubyLanguage.LOGGER.info("Percent Keyword Args Method Calls Optimizable: " + percentMethodCallsWithKwArgsOptimizable + "%");
+        RubyLanguage.LOGGER.info("Percent Method Calls Optimizable: " + percentMethodCallsOptimizable + "%");
     }
 
     public boolean isPreInitializing() {

--- a/src/main/java/org/truffleruby/language/methods/Arity.java
+++ b/src/main/java/org/truffleruby/language/methods/Arity.java
@@ -152,6 +152,10 @@ public final class Arity {
         return keywordArguments;
     }
 
+    public boolean isKeywordArgumentOptimizable() {
+        return hasKeywords() && !hasKeywordsRest();
+    }
+
     public ArgumentDescriptor[] toAnonymousArgumentDescriptors() {
         List<ArgumentDescriptor> descs = new ArrayList<>();
 

--- a/src/main/java/org/truffleruby/language/methods/CallInternalMethodNode.java
+++ b/src/main/java/org/truffleruby/language/methods/CallInternalMethodNode.java
@@ -74,10 +74,14 @@ public abstract class CallInternalMethodNode extends RubyBaseNode {
 
     @TruffleBoundary
     private static void logCall(InternalMethod method) {
-        InternalMethod.dynamicCallCounter.incrementAndGet();
+        InternalMethod.dynamicMethodCallCounter.incrementAndGet();
+
+        if (method.getSharedMethodInfo().getArity().hasKeywords()) {
+            InternalMethod.dynamicKeywordArgumentMethodCallCounter.incrementAndGet();
+        }
 
         if (method.getSharedMethodInfo().getArity().isKeywordArgumentOptimizable()) {
-            InternalMethod.optimizableCallCounter.incrementAndGet();
+            InternalMethod.optimizableMethodCallCounter.incrementAndGet();
         }
     }
 

--- a/src/main/java/org/truffleruby/language/methods/InternalMethod.java
+++ b/src/main/java/org/truffleruby/language/methods/InternalMethod.java
@@ -54,8 +54,9 @@ public class InternalMethod implements ObjectGraphNode {
     @CompilationFinal private RootCallTarget callTarget;
     private final Object capturedBlock;
 
-    public static AtomicLong dynamicCallCounter = new AtomicLong();
-    public static AtomicLong optimizableCallCounter = new AtomicLong();
+    public static AtomicLong dynamicMethodCallCounter = new AtomicLong();
+    public static AtomicLong dynamicKeywordArgumentMethodCallCounter = new AtomicLong();
+    public static AtomicLong optimizableMethodCallCounter = new AtomicLong();
 
     public static InternalMethod fromProc(
             RubyContext context,

--- a/src/main/java/org/truffleruby/language/methods/InternalMethod.java
+++ b/src/main/java/org/truffleruby/language/methods/InternalMethod.java
@@ -10,6 +10,7 @@
 package org.truffleruby.language.methods;
 
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicLong;
 
 import com.oracle.truffle.api.CompilerDirectives;
 import com.oracle.truffle.api.CompilerDirectives.CompilationFinal;
@@ -52,6 +53,9 @@ public class InternalMethod implements ObjectGraphNode {
     private final CachedSupplier<RootCallTarget> callTargetSupplier;
     @CompilationFinal private RootCallTarget callTarget;
     private final Object capturedBlock;
+
+    public static AtomicLong dynamicCallCounter = new AtomicLong();
+    public static AtomicLong optimizableCallCounter = new AtomicLong();
 
     public static InternalMethod fromProc(
             RubyContext context,


### PR DESCRIPTION
### Why 
The goal is to use this build to run SFR to see what the optimizable % looks like. 

See: https://github.com/Shopify/truffleruby-storefront-renderer/issues/117

⚠️ This change is an experiment and not meant to be shipped!!!! (Ignore the lint issue on CI) 

### Testing

Using this test script: 

```ruby
def optimizable(a:); end
def not_optimizable(a:, **rest); end

100.times do
  optimizable(a: 1)
  not_optimizable(a: 1, b:2)
end

10_000.times do
  optimizable(a: 1)
end
```

Generates: 

<img width="746" alt="Screen Shot 2021-06-22 at 4 22 27 PM" src="https://user-images.githubusercontent.com/25471753/122994063-09443a00-d376-11eb-92dd-41c71a918112.png">

----------------------------

Without the exaggerated 10_000 optimized run....

```ruby
def optimizable(a:); end
def not_optimizable(a:, **rest); end

100.times do
  optimizable(a: 1)
  not_optimizable(a: 1, b:2)
end
```

<img width="726" alt="Screen Shot 2021-06-22 at 4 23 14 PM" src="https://user-images.githubusercontent.com/25471753/122994158-25e07200-d376-11eb-8a20-a8c602a8067d.png">
