### PR TITLE
Remove most usages of rope-based single-byte optimizable checks

### DIFF
--- a/src/main/java/org/truffleruby/core/rope/RopeNodes.java
+++ b/src/main/java/org/truffleruby/core/rope/RopeNodes.java
@@ -24,17 +24,22 @@ import java.util.Arrays;
 import com.oracle.truffle.api.TruffleSafepoint;
 import com.oracle.truffle.api.dsl.Cached.Exclusive;
 import com.oracle.truffle.api.dsl.Cached.Shared;
+import com.oracle.truffle.api.library.CachedLibrary;
 import com.oracle.truffle.api.profiles.LoopConditionProfile;
+import com.oracle.truffle.api.strings.AbstractTruffleString;
+import com.oracle.truffle.api.strings.TruffleString;
 import org.jcodings.Encoding;
 import org.jcodings.specific.ASCIIEncoding;
 import org.jcodings.specific.USASCIIEncoding;
 import org.jcodings.specific.UTF8Encoding;
 import org.truffleruby.core.encoding.RubyEncoding;
+import org.truffleruby.core.encoding.TStringGuards;
 import org.truffleruby.core.string.StringAttributes;
 import org.truffleruby.core.string.StringSupport;
 import org.truffleruby.language.NotProvided;
 import org.truffleruby.language.RubyBaseNode;
 import org.truffleruby.language.control.RaiseException;
+import org.truffleruby.language.library.RubyStringLibrary;
 import org.truffleruby.utils.Utils;
 
 import com.oracle.truffle.api.CompilerDirectives;
@@ -895,17 +900,16 @@ public abstract class RopeNodes {
             }
         }
 
-        /* @Specialization protected boolean isSingleByteOptimizable(AbstractTruffleString tString,
-         * 
-         * @Cached AsciiOnlyNode asciiOnlyNode,
-         * 
-         * @Cached ConditionProfile asciiOnlyProfile,
-         * 
-         * @CachedLibrary(limit = "LIBSTRING_CACHE") RubyStringLibrary strings) { var encoding =
-         * strings.getEncoding(tString); final boolean asciiOnly = asciiOnlyNode.execute(tString, encoding);
-         * 
-         * if (asciiOnlyProfile.profile(asciiOnly)) { return true; } else { return encoding.jcoding.isSingleByte(); }
-         * } */
+        @Specialization
+        protected boolean isSingleByteOptimizable(AbstractTruffleString tString, RubyEncoding encoding,
+                @Cached ConditionProfile asciiOnlyProfile,
+                @Cached TruffleString.GetByteCodeRangeNode getByteCodeRangeNode) {
+            if (asciiOnlyProfile.profile(TStringGuards.is7Bit(tString, encoding, getByteCodeRangeNode))) {
+                return true;
+            } else {
+                return encoding.jcoding.isSingleByte();
+            }
+        }
     }
 
     @ImportStatic(CodeRange.class)

--- a/src/main/java/org/truffleruby/core/rope/RopeNodes.java
+++ b/src/main/java/org/truffleruby/core/rope/RopeNodes.java
@@ -24,7 +24,6 @@ import java.util.Arrays;
 import com.oracle.truffle.api.TruffleSafepoint;
 import com.oracle.truffle.api.dsl.Cached.Exclusive;
 import com.oracle.truffle.api.dsl.Cached.Shared;
-import com.oracle.truffle.api.library.CachedLibrary;
 import com.oracle.truffle.api.profiles.LoopConditionProfile;
 import com.oracle.truffle.api.strings.AbstractTruffleString;
 import com.oracle.truffle.api.strings.TruffleString;
@@ -39,7 +38,6 @@ import org.truffleruby.core.string.StringSupport;
 import org.truffleruby.language.NotProvided;
 import org.truffleruby.language.RubyBaseNode;
 import org.truffleruby.language.control.RaiseException;
-import org.truffleruby.language.library.RubyStringLibrary;
 import org.truffleruby.utils.Utils;
 
 import com.oracle.truffle.api.CompilerDirectives;

--- a/src/main/java/org/truffleruby/core/string/StringGuards.java
+++ b/src/main/java/org/truffleruby/core/string/StringGuards.java
@@ -10,6 +10,7 @@
 
 package org.truffleruby.core.string;
 
+import com.oracle.truffle.api.strings.AbstractTruffleString;
 import org.jcodings.Config;
 import org.truffleruby.core.encoding.RubyEncoding;
 import org.truffleruby.core.rope.CodeRange;
@@ -25,11 +26,14 @@ public class StringGuards {
         return singleByteOptimizableNode.execute(rope, encoding);
     }
 
+    public static boolean isSingleByteOptimizable(AbstractTruffleString tString, RubyEncoding encoding,
+            RopeNodes.SingleByteOptimizableNode singleByteOptimizableNode) {
+        return singleByteOptimizableNode.execute(tString, encoding);
+    }
+
     public static boolean isSingleByteOptimizable(RubyString string,
             RopeNodes.SingleByteOptimizableNode singleByteOptimizableNode) {
-
-        final Rope rope = string.rope;
-        return singleByteOptimizableNode.execute(rope, string.encoding);
+        return singleByteOptimizableNode.execute(string.tstring, string.encoding);
     }
 
     public static boolean is7Bit(Rope rope, RopeNodes.CodeRangeNode codeRangeNode) {

--- a/src/main/java/org/truffleruby/core/string/StringNodes.java
+++ b/src/main/java/org/truffleruby/core/string/StringNodes.java
@@ -3710,7 +3710,7 @@ public abstract class StringNodes {
         @Specialization(
                 guards = {
                         "!indexOutOfBounds(strings.getRope(string), byteIndex)",
-                        "isSingleByteOptimizable(strings.getRope(string), strings.getEncoding(string), singleByteOptimizableNode)" })
+                        "isSingleByteOptimizable(strings.getTString(string), strings.getEncoding(string), singleByteOptimizableNode)" })
         protected Object stringChrAtSingleByte(Object string, int byteIndex,
                 @CachedLibrary(limit = "LIBSTRING_CACHE") RubyStringLibrary strings,
                 @Cached StringByteSubstringPrimitiveNode stringByteSubstringNode,
@@ -3721,7 +3721,7 @@ public abstract class StringNodes {
         @Specialization(
                 guards = {
                         "!indexOutOfBounds(strings.getRope(string), byteIndex)",
-                        "!isSingleByteOptimizable(strings.getRope(string), strings.getEncoding(string), singleByteOptimizableNode)" })
+                        "!isSingleByteOptimizable(strings.getTString(string), strings.getEncoding(string), singleByteOptimizableNode)" })
         protected Object stringChrAt(Object string, int byteIndex,
                 @CachedLibrary(limit = "LIBSTRING_CACHE") RubyStringLibrary strings,
                 @Cached GetActualEncodingNode getActualEncodingNode,
@@ -3918,7 +3918,7 @@ public abstract class StringNodes {
                 guards = {
                         "offset >= 0",
                         "!offsetTooLarge(strings.getRope(string), offset)",
-                        "isSingleByteOptimizable(strings.getRope(string), strings.getEncoding(string), singleByteOptimizableNode)" })
+                        "isSingleByteOptimizable(strings.getTString(string), strings.getEncoding(string), singleByteOptimizableNode)" })
         protected Object stringFindCharacterSingleByte(Object string, int offset,
                 @CachedLibrary(limit = "LIBSTRING_CACHE") RubyStringLibrary strings,
                 @Cached SingleByteOptimizableNode singleByteOptimizableNode,
@@ -3931,7 +3931,7 @@ public abstract class StringNodes {
                 guards = {
                         "offset >= 0",
                         "!offsetTooLarge(strings.getRope(string), offset)",
-                        "!isSingleByteOptimizable(strings.getRope(string), strings.getEncoding(string), singleByteOptimizableNode)" })
+                        "!isSingleByteOptimizable(strings.getTString(string), strings.getEncoding(string), singleByteOptimizableNode)" })
         protected Object stringFindCharacter(Object string, int offset,
                 @CachedLibrary(limit = "LIBSTRING_CACHE") RubyStringLibrary strings,
                 @Cached GetBytesObjectNode getBytesObject,
@@ -4326,7 +4326,7 @@ public abstract class StringNodes {
 
         @Specialization(
                 guards = {
-                        "isSingleByteOptimizable(strings.getRope(string), strings.getEncoding(string), singleByteOptimizableNode)" })
+                        "isSingleByteOptimizable(strings.getTString(string), strings.getEncoding(string), singleByteOptimizableNode)" })
         protected int singleByte(Object string, int byteIndex,
                 @CachedLibrary(limit = "LIBSTRING_CACHE") RubyStringLibrary strings) {
             return byteIndex;
@@ -4698,7 +4698,7 @@ public abstract class StringNodes {
 
         @Specialization(guards = {
                 "index > 0",
-                "isSingleByteOptimizable(strings.getRope(string), strings.getEncoding(string), singleByteOptimizableNode)" })
+                "isSingleByteOptimizable(strings.getTString(string), strings.getEncoding(string), singleByteOptimizableNode)" })
         protected int singleByteOptimizable(Object string, int index,
                 @CachedLibrary(limit = "LIBSTRING_CACHE") RubyStringLibrary strings,
                 @Cached SingleByteOptimizableNode singleByteOptimizableNode) {
@@ -4707,7 +4707,7 @@ public abstract class StringNodes {
 
         @Specialization(guards = {
                 "index > 0",
-                "!isSingleByteOptimizable(strings.getRope(string), strings.getEncoding(string), singleByteOptimizableNode)",
+                "!isSingleByteOptimizable(strings.getTString(string), strings.getEncoding(string), singleByteOptimizableNode)",
                 "isFixedWidthEncoding(strings.getRope(string))" })
         protected int fixedWidthEncoding(Object string, int index,
                 @CachedLibrary(limit = "LIBSTRING_CACHE") RubyStringLibrary strings,
@@ -4729,7 +4729,7 @@ public abstract class StringNodes {
 
         @Specialization(guards = {
                 "index > 0",
-                "!isSingleByteOptimizable(strings.getRope(string), strings.getEncoding(string), singleByteOptimizableNode)",
+                "!isSingleByteOptimizable(strings.getTString(string), strings.getEncoding(string), singleByteOptimizableNode)",
                 "!isFixedWidthEncoding(strings.getRope(string))" })
         @TruffleBoundary
         protected Object other(Object string, int index,


### PR DESCRIPTION
This PR removes most usages of `RopeNodes.SingleByteOptimizableNode`. In the process, several of the string primitives were substantially rewritten to make use of new TruffleString nodes. Please note that I have not performed any performance analysis of these revised primitives. I focused only on functionality and simplifying things. In particular, some of the primitives are now a single specialization, letting TruffleString do all the heavy lifting. But, it may be beneficial for us to provide specializations for narrow cases that only apply to TruffleRuby (e.g., byte-based vs code-point based index ops with a `CR_7BIT` coderange). Part of the justification for collapsing to a single specialization was to improve interpreter performance by not repeating the same operations multiple times (e.g., getting a TruffleString from a RubyString and then getting its code point length).

Unfortunately, I wasn't able to completely remove usages of `RopeNodes.SingleByteOptimizableNode`. The last usage of the node comes from our format nodes, which were all written to work directly with ropes, relying on them to encapsulate the encoding. Converting these nodes to use TruffleString is non-trivial. I'll look at updating those nodes in another pass after this PR.