### PR TITLE
Remove most usages of rope-based single-byte optimizable checks

### DIFF
--- a/spec/ruby/optional/capi/encoding_spec.rb
+++ b/spec/ruby/optional/capi/encoding_spec.rb
@@ -613,15 +613,15 @@ describe "C-API Encoding function" do
     it 'converts a Unicode codepoint to a UTF-8 C string' do
       str = ' ' * 6
       {
-        0  => "\x01",
-        0x7f => "\xC2\x80",
-        0x7ff => "\xE0\xA0\x80",
-        0xffff => "\xF0\x90\x80\x80",
-        0x1fffff => "\xF8\x88\x80\x80\x80",
-        0x3ffffff => "\xFC\x84\x80\x80\x80\x80",
+        1  => "\x01",
+        0x80 => "\xC2\x80",
+        0x800 => "\xE0\xA0\x80",
+        0x10000 => "\xF0\x90\x80\x80",
+        0x200000 => "\xF8\x88\x80\x80\x80",
+        0x4000000 => "\xFC\x84\x80\x80\x80\x80",
       }.each do |num, result|
-        len = @s.rb_uv_to_utf8(str, num + 1)
-        str[0..len-1].should == result
+        len = @s.rb_uv_to_utf8(str, num)
+        str.byteslice(0, len).should == result
       end
     end
   end

--- a/spec/ruby/optional/capi/ext/encoding_spec.c
+++ b/spec/ruby/optional/capi/ext/encoding_spec.c
@@ -275,7 +275,9 @@ static VALUE encoding_spec_rb_enc_str_asciionly_p(VALUE self, VALUE str) {
 }
 
 static VALUE encoding_spec_rb_uv_to_utf8(VALUE self, VALUE buf, VALUE num) {
-  return INT2NUM(rb_uv_to_utf8(RSTRING_PTR(buf), NUM2INT(num)));
+  int len = rb_uv_to_utf8(RSTRING_PTR(buf), NUM2INT(num));
+  RB_ENC_CODERANGE_CLEAR(buf);
+  return INT2NUM(len);
 }
 
 static VALUE encoding_spec_ONIGENC_MBC_CASE_FOLD(VALUE self, VALUE str) {

--- a/src/main/java/org/truffleruby/core/hash/HashNodes.java
+++ b/src/main/java/org/truffleruby/core/hash/HashNodes.java
@@ -233,7 +233,7 @@ public abstract class HashNodes {
     @ImportStatic(HashGuards.class)
     public abstract static class ClearNode extends CoreMethodArrayArgumentsNode {
 
-        @Specialization(limit = "2")
+        @Specialization(limit = "hashStrategyLimit()")
         protected RubyHash clear(RubyHash hash,
                 @CachedLibrary("hash.store") HashStoreLibrary hashes) {
             hashes.clear(hash.store, hash);

--- a/src/main/java/org/truffleruby/core/hash/library/PackedHashStoreLibrary.java
+++ b/src/main/java/org/truffleruby/core/hash/library/PackedHashStoreLibrary.java
@@ -165,6 +165,7 @@ public class PackedHashStoreLibrary {
         return lookupPackedEntryNode.execute(frame, hash, key, hashed, defaultNode);
     }
 
+    @ImportStatic(HashGuards.class)
     @ExportMessage
     protected static class Set {
         @Specialization(guards = "hash.size == 0")
@@ -190,7 +191,7 @@ public class PackedHashStoreLibrary {
                 @Cached @Shared("propagateKey") PropagateSharingNode propagateSharingKey,
                 @Cached @Shared("propagateValue") PropagateSharingNode propagateSharingValue,
                 @Cached @Shared("compareHashKeys") CompareHashKeysNode compareHashKeys,
-                @CachedLibrary(limit = "2") HashStoreLibrary hashes,
+                @CachedLibrary(limit = "hashStrategyLimit()") HashStoreLibrary hashes,
                 @Cached ConditionProfile withinCapacity) {
 
             assert verify(store, hash);

--- a/src/main/java/org/truffleruby/core/regexp/InterpolatedRegexpNode.java
+++ b/src/main/java/org/truffleruby/core/regexp/InterpolatedRegexpNode.java
@@ -34,7 +34,7 @@ public class InterpolatedRegexpNode extends RubyContextSourceNode {
     public InterpolatedRegexpNode(ToSNode[] children, RegexpOptions options) {
         this.children = children;
         builderNode = RegexpBuilderNode.create(options);
-        rubyStringLibrary = RubyStringLibrary.getFactory().createDispatched(2);
+        rubyStringLibrary = RubyStringLibrary.createDispatched();
     }
 
     @Override

--- a/src/main/java/org/truffleruby/core/regexp/MatchDataNodes.java
+++ b/src/main/java/org/truffleruby/core/regexp/MatchDataNodes.java
@@ -37,9 +37,9 @@ import org.truffleruby.core.klass.RubyClass;
 import org.truffleruby.core.range.RubyIntRange;
 import org.truffleruby.core.regexp.MatchDataNodesFactory.ValuesNodeFactory;
 import org.truffleruby.core.rope.Rope;
-import org.truffleruby.core.rope.RopeNodes;
 import org.truffleruby.core.rope.RopeOperations;
 import org.truffleruby.core.string.RubyString;
+import org.truffleruby.core.string.StringNodes;
 import org.truffleruby.core.string.StringSupport;
 import org.truffleruby.core.string.StringUtils;
 import org.truffleruby.core.symbol.RubySymbol;
@@ -446,7 +446,7 @@ public abstract class MatchDataNodes {
                 @Cached ConditionProfile lazyProfile,
                 @Cached ConditionProfile negativeBeginProfile,
                 @Cached ConditionProfile multiByteCharacterProfile,
-                @Cached RopeNodes.SingleByteOptimizableNode singleByteOptimizableNode,
+                @Cached StringNodes.NewSingleByteOptimizableNode singleByteOptimizableNode,
                 @CachedLibrary(limit = "LIBSTRING_CACHE") RubyStringLibrary strings,
                 @CachedLibrary(limit = "getInteropCacheLimit()") InteropLibrary interop) {
             final int begin = getStart(matchData, index, lazyProfile, interop);
@@ -532,7 +532,7 @@ public abstract class MatchDataNodes {
                 @Cached ConditionProfile lazyProfile,
                 @Cached ConditionProfile negativeEndProfile,
                 @Cached ConditionProfile multiByteCharacterProfile,
-                @Cached RopeNodes.SingleByteOptimizableNode singleByteOptimizableNode,
+                @Cached StringNodes.NewSingleByteOptimizableNode singleByteOptimizableNode,
                 @CachedLibrary(limit = "LIBSTRING_CACHE") RubyStringLibrary strings,
                 @CachedLibrary(limit = "getInteropCacheLimit()") InteropLibrary interop) {
             final int end = getEnd(matchData, index, lazyProfile, interop);

--- a/src/main/java/org/truffleruby/core/regexp/TruffleRegexpNodes.java
+++ b/src/main/java/org/truffleruby/core/regexp/TruffleRegexpNodes.java
@@ -112,7 +112,7 @@ public class TruffleRegexpNodes {
     public abstract static class PrepareRegexpEncodingNode extends PrimitiveArrayArgumentsNode {
 
         @Child RopeNodes.CodeRangeNode codeRangeNode = RopeNodes.CodeRangeNode.create();
-        @Child RubyStringLibrary stringLibrary = RubyStringLibrary.getFactory().createDispatched(2);
+        @Child RubyStringLibrary stringLibrary = RubyStringLibrary.createDispatched();
         @Child WarnNode warnNode;
 
         public static PrepareRegexpEncodingNode create() {
@@ -285,7 +285,7 @@ public class TruffleRegexpNodes {
         @Child ToSNode toSNode = ToSNode.create();
         @Child DispatchNode copyNode = DispatchNode.create();
         @Child private SameOrEqualNode sameOrEqualNode = SameOrEqualNode.create();
-        @Child private RubyStringLibrary rubyStringLibrary = RubyStringLibrary.getFactory().createDispatched(2);
+        @Child private RubyStringLibrary rubyStringLibrary = RubyStringLibrary.createDispatched();
 
         @Specialization(
                 guards = "argsMatch(frame, cachedArgs, args)",

--- a/src/main/java/org/truffleruby/core/rope/RopeNodes.java
+++ b/src/main/java/org/truffleruby/core/rope/RopeNodes.java
@@ -24,17 +24,22 @@ import java.util.Arrays;
 import com.oracle.truffle.api.TruffleSafepoint;
 import com.oracle.truffle.api.dsl.Cached.Exclusive;
 import com.oracle.truffle.api.dsl.Cached.Shared;
+import com.oracle.truffle.api.library.CachedLibrary;
 import com.oracle.truffle.api.profiles.LoopConditionProfile;
+import com.oracle.truffle.api.strings.AbstractTruffleString;
+import com.oracle.truffle.api.strings.TruffleString;
 import org.jcodings.Encoding;
 import org.jcodings.specific.ASCIIEncoding;
 import org.jcodings.specific.USASCIIEncoding;
 import org.jcodings.specific.UTF8Encoding;
 import org.truffleruby.core.encoding.RubyEncoding;
+import org.truffleruby.core.encoding.TStringGuards;
 import org.truffleruby.core.string.StringAttributes;
 import org.truffleruby.core.string.StringSupport;
 import org.truffleruby.language.NotProvided;
 import org.truffleruby.language.RubyBaseNode;
 import org.truffleruby.language.control.RaiseException;
+import org.truffleruby.language.library.RubyStringLibrary;
 import org.truffleruby.utils.Utils;
 
 import com.oracle.truffle.api.CompilerDirectives;
@@ -895,17 +900,16 @@ public abstract class RopeNodes {
             }
         }
 
-        /* @Specialization protected boolean isSingleByteOptimizable(AbstractTruffleString tString,
-         * 
-         * @Cached AsciiOnlyNode asciiOnlyNode,
-         * 
-         * @Cached ConditionProfile asciiOnlyProfile,
-         * 
-         * @CachedLibrary(limit = "LIBSTRING_CACHE") RubyStringLibrary strings) { var encoding =
-         * strings.getEncoding(tString); final boolean asciiOnly = asciiOnlyNode.execute(tString, encoding);
-         * 
-         * if (asciiOnlyProfile.profile(asciiOnly)) { return true; } else { return encoding.jcoding.isSingleByte(); }
-         * } */
+        @Specialization
+        protected boolean isSingleByteOptimizable(AbstractTruffleString tString, RubyEncoding encoding,
+                @Cached ConditionProfile asciiOnlyProfile,
+                @Cached TruffleString.GetByteCodeRangeNode getByteCodeRangeNode) {
+            if (asciiOnlyProfile.profile(TStringGuards.is7Bit(tString, encoding, getByteCodeRangeNode))) {
+                return true;
+            } else {
+                return encoding.jcoding.isSingleByte();
+            }
+        }
     }
 
     @ImportStatic(CodeRange.class)

--- a/src/main/java/org/truffleruby/core/rope/RopeNodes.java
+++ b/src/main/java/org/truffleruby/core/rope/RopeNodes.java
@@ -26,14 +26,13 @@ import com.oracle.truffle.api.dsl.Cached.Exclusive;
 import com.oracle.truffle.api.dsl.Cached.Shared;
 import com.oracle.truffle.api.profiles.LoopConditionProfile;
 import com.oracle.truffle.api.strings.AbstractTruffleString;
-import com.oracle.truffle.api.strings.TruffleString;
 import org.jcodings.Encoding;
 import org.jcodings.specific.ASCIIEncoding;
 import org.jcodings.specific.USASCIIEncoding;
 import org.jcodings.specific.UTF8Encoding;
 import org.truffleruby.core.encoding.RubyEncoding;
-import org.truffleruby.core.encoding.TStringGuards;
 import org.truffleruby.core.string.StringAttributes;
+import org.truffleruby.core.string.StringNodes;
 import org.truffleruby.core.string.StringSupport;
 import org.truffleruby.language.NotProvided;
 import org.truffleruby.language.RubyBaseNode;
@@ -900,13 +899,8 @@ public abstract class RopeNodes {
 
         @Specialization
         protected boolean isSingleByteOptimizable(AbstractTruffleString tString, RubyEncoding encoding,
-                @Cached ConditionProfile asciiOnlyProfile,
-                @Cached TruffleString.GetByteCodeRangeNode getByteCodeRangeNode) {
-            if (asciiOnlyProfile.profile(TStringGuards.is7Bit(tString, encoding, getByteCodeRangeNode))) {
-                return true;
-            } else {
-                return encoding.jcoding.isSingleByte();
-            }
+                @Cached StringNodes.NewSingleByteOptimizableNode singleByteOptimizableNode) {
+            return singleByteOptimizableNode.execute(tString, encoding);
         }
     }
 

--- a/src/main/java/org/truffleruby/core/rope/RopeNodes.java
+++ b/src/main/java/org/truffleruby/core/rope/RopeNodes.java
@@ -25,14 +25,12 @@ import com.oracle.truffle.api.TruffleSafepoint;
 import com.oracle.truffle.api.dsl.Cached.Exclusive;
 import com.oracle.truffle.api.dsl.Cached.Shared;
 import com.oracle.truffle.api.profiles.LoopConditionProfile;
-import com.oracle.truffle.api.strings.AbstractTruffleString;
 import org.jcodings.Encoding;
 import org.jcodings.specific.ASCIIEncoding;
 import org.jcodings.specific.USASCIIEncoding;
 import org.jcodings.specific.UTF8Encoding;
 import org.truffleruby.core.encoding.RubyEncoding;
 import org.truffleruby.core.string.StringAttributes;
-import org.truffleruby.core.string.StringNodes;
 import org.truffleruby.core.string.StringSupport;
 import org.truffleruby.language.NotProvided;
 import org.truffleruby.language.RubyBaseNode;
@@ -884,7 +882,7 @@ public abstract class RopeNodes {
             return RopeNodesFactory.SingleByteOptimizableNodeGen.create();
         }
 
-        public abstract boolean execute(Object object, RubyEncoding encoding);
+        public abstract boolean execute(Rope rope, RubyEncoding encoding);
 
         @Specialization
         protected boolean isSingleByteOptimizable(Rope rope, RubyEncoding encoding,
@@ -895,12 +893,6 @@ public abstract class RopeNodes {
             } else {
                 return rope.getEncoding().isSingleByte();
             }
-        }
-
-        @Specialization
-        protected boolean isSingleByteOptimizable(AbstractTruffleString tString, RubyEncoding encoding,
-                @Cached StringNodes.NewSingleByteOptimizableNode singleByteOptimizableNode) {
-            return singleByteOptimizableNode.execute(tString, encoding);
         }
     }
 

--- a/src/main/java/org/truffleruby/core/rope/RopeNodes.java
+++ b/src/main/java/org/truffleruby/core/rope/RopeNodes.java
@@ -24,7 +24,6 @@ import java.util.Arrays;
 import com.oracle.truffle.api.TruffleSafepoint;
 import com.oracle.truffle.api.dsl.Cached.Exclusive;
 import com.oracle.truffle.api.dsl.Cached.Shared;
-import com.oracle.truffle.api.library.CachedLibrary;
 import com.oracle.truffle.api.profiles.LoopConditionProfile;
 import com.oracle.truffle.api.strings.AbstractTruffleString;
 import com.oracle.truffle.api.strings.TruffleString;
@@ -39,7 +38,6 @@ import org.truffleruby.core.string.StringSupport;
 import org.truffleruby.language.NotProvided;
 import org.truffleruby.language.RubyBaseNode;
 import org.truffleruby.language.control.RaiseException;
-import org.truffleruby.language.library.RubyStringLibrary;
 import org.truffleruby.utils.Utils;
 
 import com.oracle.truffle.api.CompilerDirectives;

--- a/src/main/java/org/truffleruby/core/string/StringGuards.java
+++ b/src/main/java/org/truffleruby/core/string/StringGuards.java
@@ -94,21 +94,21 @@ public class StringGuards {
     /** The string can be optimized to single-byte representation and is a simple case mapping (ASCII-only or full
      * Unicode). */
     public static boolean isSingleByteCaseMapping(RubyString string, int caseMappingOptions,
-            RopeNodes.SingleByteOptimizableNode singleByteOptimizableNode) {
+            StringNodes.NewSingleByteOptimizableNode singleByteOptimizableNode) {
         return isSingleByteOptimizable(string, singleByteOptimizableNode) && isAsciiCompatMapping(caseMappingOptions);
     }
 
     /** The string's encoding is ASCII-compatible, the mapping is ASCII-only and {@link #isSingleByteCaseMapping} is not
      * applicable. */
     public static boolean isSimpleAsciiCaseMapping(RubyString string, int caseMappingOptions,
-            RopeNodes.SingleByteOptimizableNode singleByteOptimizableNode) {
+            StringNodes.NewSingleByteOptimizableNode singleByteOptimizableNode) {
         return !isSingleByteOptimizable(string, singleByteOptimizableNode) &&
                 caseMappingOptions == Config.CASE_ASCII_ONLY && isAsciiCompatible(string);
     }
 
     /** Both {@link #isSingleByteCaseMapping} and {@link #isSimpleAsciiCaseMapping} are not applicable. */
     public static boolean isComplexCaseMapping(RubyString string, int caseMappingOptions,
-            RopeNodes.SingleByteOptimizableNode singleByteOptimizableNode) {
+            StringNodes.NewSingleByteOptimizableNode singleByteOptimizableNode) {
         return !isSingleByteCaseMapping(string, caseMappingOptions, singleByteOptimizableNode) &&
                 !isSimpleAsciiCaseMapping(string, caseMappingOptions, singleByteOptimizableNode);
     }

--- a/src/main/java/org/truffleruby/core/string/StringGuards.java
+++ b/src/main/java/org/truffleruby/core/string/StringGuards.java
@@ -10,6 +10,7 @@
 
 package org.truffleruby.core.string;
 
+import com.oracle.truffle.api.strings.AbstractTruffleString;
 import org.jcodings.Config;
 import org.truffleruby.core.encoding.RubyEncoding;
 import org.truffleruby.core.rope.CodeRange;
@@ -25,11 +26,14 @@ public class StringGuards {
         return singleByteOptimizableNode.execute(rope, encoding);
     }
 
+    public static boolean isSingleByteOptimizable(AbstractTruffleString tString, RubyEncoding encoding,
+            RopeNodes.SingleByteOptimizableNode singleByteOptimizableNode) {
+        return singleByteOptimizableNode.execute(tString, encoding);
+    }
+
     public static boolean isSingleByteOptimizable(RubyString string,
             RopeNodes.SingleByteOptimizableNode singleByteOptimizableNode) {
-
-        final Rope rope = string.rope;
-        return singleByteOptimizableNode.execute(rope, string.encoding);
+        return singleByteOptimizableNode.execute(string.tstring, string.encoding);
     }
 
     public static boolean is7Bit(Rope rope, RopeNodes.CodeRangeNode codeRangeNode) {

--- a/src/main/java/org/truffleruby/core/string/StringGuards.java
+++ b/src/main/java/org/truffleruby/core/string/StringGuards.java
@@ -36,6 +36,16 @@ public class StringGuards {
         return singleByteOptimizableNode.execute(string.tstring, string.encoding);
     }
 
+    public static boolean isSingleByteOptimizable(RubyString string,
+            StringNodes.NewSingleByteOptimizableNode singleByteOptimizableNode) {
+        return singleByteOptimizableNode.execute(string.tstring, string.encoding);
+    }
+
+    public static boolean isSingleByteOptimizable(AbstractTruffleString tString, RubyEncoding encoding,
+            StringNodes.NewSingleByteOptimizableNode singleByteOptimizableNode) {
+        return singleByteOptimizableNode.execute(tString, encoding);
+    }
+
     public static boolean is7Bit(Rope rope, RopeNodes.CodeRangeNode codeRangeNode) {
         return codeRangeNode.execute(rope) == CodeRange.CR_7BIT;
     }

--- a/src/main/java/org/truffleruby/core/string/StringGuards.java
+++ b/src/main/java/org/truffleruby/core/string/StringGuards.java
@@ -78,13 +78,15 @@ public class StringGuards {
         return rope.byteLength() == 1;
     }
 
-    public static boolean canMemcmp(Rope sourceRope, Rope patternRope, RubyEncoding sourceEncoding,
+    public static boolean canMemcmp(AbstractTruffleString sourceRope, AbstractTruffleString patternRope,
+            RubyEncoding sourceEncoding,
             RubyEncoding patternEncoding,
-            RopeNodes.SingleByteOptimizableNode singleByteNode) {
+            StringNodes.NewSingleByteOptimizableNode singleByteNode) {
 
-        return (singleByteNode.execute(sourceRope, sourceEncoding) || sourceRope.getEncoding().isUTF8()) &&
-                (singleByteNode.execute(patternRope, patternEncoding) || patternRope.getEncoding().isUTF8());
+        return (singleByteNode.execute(sourceRope, sourceEncoding) || sourceEncoding.jcoding.isUTF8()) &&
+                (singleByteNode.execute(patternRope, patternEncoding) || patternEncoding.jcoding.isUTF8());
     }
+
 
     /** The case mapping is simple (ASCII-only or full Unicode): no complex option like Turkic, case-folding, etc. */
     public static boolean isAsciiCompatMapping(int caseMappingOptions) {

--- a/src/main/java/org/truffleruby/core/string/StringGuards.java
+++ b/src/main/java/org/truffleruby/core/string/StringGuards.java
@@ -21,21 +21,6 @@ public class StringGuards {
 
     private static final int CASE_FULL_UNICODE = 0;
 
-    public static boolean isSingleByteOptimizable(Rope rope, RubyEncoding encoding,
-            RopeNodes.SingleByteOptimizableNode singleByteOptimizableNode) {
-        return singleByteOptimizableNode.execute(rope, encoding);
-    }
-
-    public static boolean isSingleByteOptimizable(AbstractTruffleString tString, RubyEncoding encoding,
-            RopeNodes.SingleByteOptimizableNode singleByteOptimizableNode) {
-        return singleByteOptimizableNode.execute(tString, encoding);
-    }
-
-    public static boolean isSingleByteOptimizable(RubyString string,
-            RopeNodes.SingleByteOptimizableNode singleByteOptimizableNode) {
-        return singleByteOptimizableNode.execute(string.tstring, string.encoding);
-    }
-
     public static boolean isSingleByteOptimizable(RubyString string,
             StringNodes.NewSingleByteOptimizableNode singleByteOptimizableNode) {
         return singleByteOptimizableNode.execute(string.tstring, string.encoding);

--- a/src/main/java/org/truffleruby/core/string/StringNodes.java
+++ b/src/main/java/org/truffleruby/core/string/StringNodes.java
@@ -3710,7 +3710,7 @@ public abstract class StringNodes {
         @Specialization(
                 guards = {
                         "!indexOutOfBounds(strings.getRope(string), byteIndex)",
-                        "isSingleByteOptimizable(strings.getRope(string), strings.getEncoding(string), singleByteOptimizableNode)" })
+                        "isSingleByteOptimizable(strings.getTString(string), strings.getEncoding(string), singleByteOptimizableNode)" })
         protected Object stringChrAtSingleByte(Object string, int byteIndex,
                 @CachedLibrary(limit = "LIBSTRING_CACHE") RubyStringLibrary strings,
                 @Cached StringByteSubstringPrimitiveNode stringByteSubstringNode,
@@ -3721,7 +3721,7 @@ public abstract class StringNodes {
         @Specialization(
                 guards = {
                         "!indexOutOfBounds(strings.getRope(string), byteIndex)",
-                        "!isSingleByteOptimizable(strings.getRope(string), strings.getEncoding(string), singleByteOptimizableNode)" })
+                        "!isSingleByteOptimizable(strings.getTString(string), strings.getEncoding(string), singleByteOptimizableNode)" })
         protected Object stringChrAt(Object string, int byteIndex,
                 @CachedLibrary(limit = "LIBSTRING_CACHE") RubyStringLibrary strings,
                 @Cached GetActualEncodingNode getActualEncodingNode,
@@ -3918,7 +3918,7 @@ public abstract class StringNodes {
                 guards = {
                         "offset >= 0",
                         "!offsetTooLarge(strings.getRope(string), offset)",
-                        "isSingleByteOptimizable(strings.getRope(string), strings.getEncoding(string), singleByteOptimizableNode)" })
+                        "isSingleByteOptimizable(strings.getTString(string), strings.getEncoding(string), singleByteOptimizableNode)" })
         protected Object stringFindCharacterSingleByte(Object string, int offset,
                 @CachedLibrary(limit = "LIBSTRING_CACHE") RubyStringLibrary strings,
                 @Cached SingleByteOptimizableNode singleByteOptimizableNode,
@@ -3931,7 +3931,7 @@ public abstract class StringNodes {
                 guards = {
                         "offset >= 0",
                         "!offsetTooLarge(strings.getRope(string), offset)",
-                        "!isSingleByteOptimizable(strings.getRope(string), strings.getEncoding(string), singleByteOptimizableNode)" })
+                        "!isSingleByteOptimizable(strings.getTString(string), strings.getEncoding(string), singleByteOptimizableNode)" })
         protected Object stringFindCharacter(Object string, int offset,
                 @CachedLibrary(limit = "LIBSTRING_CACHE") RubyStringLibrary strings,
                 @Cached GetBytesObjectNode getBytesObject,
@@ -4326,7 +4326,7 @@ public abstract class StringNodes {
 
         @Specialization(
                 guards = {
-                        "isSingleByteOptimizable(strings.getRope(string), strings.getEncoding(string), singleByteOptimizableNode)" })
+                        "isSingleByteOptimizable(strings.getTString(string), strings.getEncoding(string), singleByteOptimizableNode)" })
         protected int singleByte(Object string, int byteIndex,
                 @CachedLibrary(limit = "LIBSTRING_CACHE") RubyStringLibrary strings) {
             return byteIndex;
@@ -4698,7 +4698,7 @@ public abstract class StringNodes {
 
         @Specialization(guards = {
                 "index > 0",
-                "isSingleByteOptimizable(strings.getRope(string), strings.getEncoding(string), singleByteOptimizableNode)" })
+                "isSingleByteOptimizable(strings.getTString(string), strings.getEncoding(string), singleByteOptimizableNode)" })
         protected int singleByteOptimizable(Object string, int index,
                 @CachedLibrary(limit = "LIBSTRING_CACHE") RubyStringLibrary strings,
                 @Cached SingleByteOptimizableNode singleByteOptimizableNode) {
@@ -4707,7 +4707,7 @@ public abstract class StringNodes {
 
         @Specialization(guards = {
                 "index > 0",
-                "!isSingleByteOptimizable(strings.getRope(string), strings.getEncoding(string), singleByteOptimizableNode)",
+                "!isSingleByteOptimizable(strings.getTString(string), strings.getEncoding(string), singleByteOptimizableNode)",
                 "isFixedWidthEncoding(strings.getRope(string))" })
         protected int fixedWidthEncoding(Object string, int index,
                 @CachedLibrary(limit = "LIBSTRING_CACHE") RubyStringLibrary strings,
@@ -4729,7 +4729,7 @@ public abstract class StringNodes {
 
         @Specialization(guards = {
                 "index > 0",
-                "!isSingleByteOptimizable(strings.getRope(string), strings.getEncoding(string), singleByteOptimizableNode)",
+                "!isSingleByteOptimizable(strings.getTString(string), strings.getEncoding(string), singleByteOptimizableNode)",
                 "!isFixedWidthEncoding(strings.getRope(string))" })
         @TruffleBoundary
         protected Object other(Object string, int index,

--- a/src/main/java/org/truffleruby/core/string/StringNodes.java
+++ b/src/main/java/org/truffleruby/core/string/StringNodes.java
@@ -1347,7 +1347,7 @@ public abstract class StringNodes {
     @ImportStatic({ StringGuards.class, Config.class })
     public abstract static class StringDowncaseBangPrimitiveNode extends PrimitiveArrayArgumentsNode {
 
-        @Child SingleByteOptimizableNode singleByteOptimizableNode = SingleByteOptimizableNode.create();
+        @Child NewSingleByteOptimizableNode singleByteOptimizableNode = NewSingleByteOptimizableNode.create();
 
         @Specialization(guards = { "isSingleByteCaseMapping(string, caseMappingOptions, singleByteOptimizableNode)" })
         protected Object downcaseSingleByte(RubyString string, int caseMappingOptions,
@@ -2141,7 +2141,7 @@ public abstract class StringNodes {
     @ImportStatic({ StringGuards.class, Config.class })
     public abstract static class StringSwapcaseBangPrimitiveNode extends PrimitiveArrayArgumentsNode {
 
-        @Child SingleByteOptimizableNode singleByteOptimizableNode = SingleByteOptimizableNode.create();
+        @Child NewSingleByteOptimizableNode singleByteOptimizableNode = NewSingleByteOptimizableNode.create();
 
         @Specialization(guards = { "isSingleByteCaseMapping(string, caseMappingOptions, singleByteOptimizableNode)" })
         protected Object swapcaseSingleByte(RubyString string, int caseMappingOptions,
@@ -3191,8 +3191,7 @@ public abstract class StringNodes {
     @ImportStatic({ StringGuards.class, Config.class })
     public abstract static class StringUpcaseBangPrimitiveNode extends PrimitiveArrayArgumentsNode {
 
-        @Child SingleByteOptimizableNode singleByteOptimizableNode = SingleByteOptimizableNode
-                .create();
+        @Child NewSingleByteOptimizableNode singleByteOptimizableNode = NewSingleByteOptimizableNode.create();
 
         @Specialization(guards = { "isSingleByteCaseMapping(string, caseMappingOptions, singleByteOptimizableNode)" })
         protected Object upcaseSingleByte(RubyString string, int caseMappingOptions,
@@ -3279,7 +3278,7 @@ public abstract class StringNodes {
         @Child private BytesNode bytesNode = BytesNode.create();
         @Child private CodeRangeNode codeRangeNode = CodeRangeNode.create();
         @Child private TruffleString.FromByteArrayNode fromByteArrayNode = TruffleString.FromByteArrayNode.create();
-        @Child SingleByteOptimizableNode singleByteOptimizableNode = SingleByteOptimizableNode.create();
+        @Child NewSingleByteOptimizableNode singleByteOptimizableNode = NewSingleByteOptimizableNode.create();
 
         @Specialization(guards = "isSingleByteCaseMapping(string, caseMappingOptions, singleByteOptimizableNode)")
         protected Object capitalizeSingleByte(RubyString string, int caseMappingOptions,

--- a/src/main/java/org/truffleruby/core/string/StringNodes.java
+++ b/src/main/java/org/truffleruby/core/string/StringNodes.java
@@ -4081,7 +4081,7 @@ public abstract class StringNodes {
 
         @Child private CheckEncodingNode checkEncodingNode;
         @Child CodeRangeNode codeRangeNode = CodeRangeNode.create();
-        @Child SingleByteOptimizableNode singleByteNode = SingleByteOptimizableNode.create();
+        @Child NewSingleByteOptimizableNode singleByteNode = NewSingleByteOptimizableNode.create();
 
         @Specialization(
                 guards = "isEmpty(stringsPattern.getRope(pattern))")
@@ -4095,7 +4095,7 @@ public abstract class StringNodes {
                 guards = {
                         "isSingleByteString(libPattern.getRope(pattern))",
                         "!isBrokenCodeRange(libPattern.getRope(pattern), codeRangeNode)",
-                        "canMemcmp(libString.getRope(string), libPattern.getRope(pattern), " +
+                        "canMemcmp(libString.getTString(string), libPattern.getTString(pattern), " +
                                 "libString.getEncoding(string), libPattern.getEncoding(pattern), singleByteNode)" })
         protected Object stringIndexSingleBytePattern(Object string, Object pattern, int byteOffset,
                 @Cached BytesNode bytesNode,
@@ -4126,8 +4126,8 @@ public abstract class StringNodes {
                         "!isEmpty(libPattern.getRope(pattern))",
                         "!isSingleByteString(libPattern.getRope(pattern))",
                         "!isBrokenCodeRange(libPattern.getRope(pattern), codeRangeNode)",
-                        "canMemcmp(libString.getRope(string), libPattern.getRope(pattern), " +
-                                "libString.getEncoding(string), libPattern.getEncoding(pattern),singleByteNode)" })
+                        "canMemcmp(libString.getTString(string), libPattern.getTString(pattern), " +
+                                "libString.getEncoding(string), libPattern.getEncoding(pattern), singleByteNode)" })
         protected Object stringIndexMultiBytePattern(Object string, Object pattern, int byteOffset,
                 @Cached BytesNode bytesNode,
                 @Cached BranchProfile matchFoundProfile,
@@ -4177,7 +4177,7 @@ public abstract class StringNodes {
         @Specialization(
                 guards = {
                         "!isBrokenCodeRange(libPattern.getRope(pattern), codeRangeNode)",
-                        "!canMemcmp(libString.getRope(string), libPattern.getRope(pattern), " +
+                        "!canMemcmp(libString.getTString(string), libPattern.getTString(pattern), " +
                                 "libString.getEncoding(string), libPattern.getEncoding(pattern), singleByteNode)" })
         protected Object stringIndexGeneric(Object string, Object pattern, int byteOffset,
                 @Cached ByteIndexFromCharIndexNode byteIndexFromCharIndexNode,
@@ -4754,7 +4754,7 @@ public abstract class StringNodes {
 
         @Child private CheckEncodingNode checkEncodingNode;
         @Child CodeRangeNode codeRangeNode = CodeRangeNode.create();
-        @Child SingleByteOptimizableNode singleByteNode = SingleByteOptimizableNode.create();
+        @Child NewSingleByteOptimizableNode singleByteNode = NewSingleByteOptimizableNode.create();
 
         @Specialization(guards = { "isEmpty(stringsPattern.getRope(pattern))" })
         protected Object stringRindexEmptyPattern(Object string, Object pattern, int byteOffset,
@@ -4766,11 +4766,12 @@ public abstract class StringNodes {
         @Specialization(guards = {
                 "isSingleByteString(patternRope)",
                 "!isBrokenCodeRange(patternRope, codeRangeNode)",
-                "canMemcmp(libString.getRope(string), patternRope, " +
+                "canMemcmp(libString.getTString(string), patternTString, " +
                         "libString.getEncoding(string), libPattern.getEncoding(pattern), singleByteNode)" })
         protected Object stringRindexSingleBytePattern(Object string, Object pattern, int byteOffset,
                 @CachedLibrary(limit = "LIBSTRING_CACHE") RubyStringLibrary libPattern,
                 @Bind("libPattern.getRope(pattern)") Rope patternRope,
+                @Bind("libPattern.getTString(pattern)") AbstractTruffleString patternTString,
                 @Cached BytesNode bytesNode,
                 @Cached BranchProfile startTooLargeProfile,
                 @Cached BranchProfile matchFoundProfile,
@@ -4813,11 +4814,12 @@ public abstract class StringNodes {
                 "!isEmpty(patternRope)",
                 "!isSingleByteString(patternRope)",
                 "!isBrokenCodeRange(patternRope, codeRangeNode)",
-                "canMemcmp(libString.getRope(string), patternRope, " +
+                "canMemcmp(libString.getTString(string), patternTString, " +
                         "libString.getEncoding(string), libPattern.getEncoding(pattern), singleByteNode)" })
         protected Object stringRindexMultiBytePattern(Object string, Object pattern, int byteOffset,
                 @CachedLibrary(limit = "LIBSTRING_CACHE") RubyStringLibrary libPattern,
                 @Bind("libPattern.getRope(pattern)") Rope patternRope,
+                @Bind("libPattern.getTString(pattern)") AbstractTruffleString patternTString,
                 @Cached BytesNode bytesNode,
                 @Cached BranchProfile startOutOfBoundsProfile,
                 @Cached BranchProfile startTooCloseToEndProfile,
@@ -4874,11 +4876,12 @@ public abstract class StringNodes {
 
         @Specialization(guards = {
                 "!isBrokenCodeRange(patternRope, codeRangeNode)",
-                "!canMemcmp(libString.getRope(string), patternRope, " +
+                "!canMemcmp(libString.getTString(string), patternTString, " +
                         "libString.getEncoding(string), libPattern.getEncoding(pattern), singleByteNode)" })
         protected Object stringRindex(Object string, Object pattern, int byteOffset,
                 @CachedLibrary(limit = "LIBSTRING_CACHE") RubyStringLibrary libPattern,
                 @Bind("libPattern.getRope(pattern)") Rope patternRope,
+                @Bind("libPattern.getTString(pattern)") AbstractTruffleString patternTString,
                 @Cached BytesNode stringBytes,
                 @Cached BytesNode patternBytes,
                 @Cached GetByteNode patternGetByteNode,

--- a/src/main/java/org/truffleruby/core/string/StringNodes.java
+++ b/src/main/java/org/truffleruby/core/string/StringNodes.java
@@ -1051,7 +1051,7 @@ public abstract class StringNodes {
 
         @Child private ToStrNode toStr = ToStrNode.create();
         @Child private CountRopesNode countRopesNode = CountRopesNode.create();
-        @Child private RubyStringLibrary rubyStringLibrary = RubyStringLibrary.getFactory().createDispatched(2);
+        @Child private RubyStringLibrary rubyStringLibrary = RubyStringLibrary.createDispatched();
 
         @Specialization(
                 guards = "args.length == size",
@@ -1220,7 +1220,7 @@ public abstract class StringNodes {
 
         @Child private ToStrNode toStr = ToStrNode.create();
         @Child private DeleteBangRopesNode deleteBangRopesNode = DeleteBangRopesNode.create();
-        @Child private RubyStringLibrary rubyStringLibrary = RubyStringLibrary.getFactory().createDispatched(2);
+        @Child private RubyStringLibrary rubyStringLibrary = RubyStringLibrary.createDispatched();
 
         public static DeleteBangNode create() {
             return DeleteBangNodeFactory.create(null);
@@ -4185,8 +4185,8 @@ public abstract class StringNodes {
     @Primitive(name = "string_character_index", lowerFixnum = 2)
     public abstract static class StringCharacterIndexNode extends PrimitiveArrayArgumentsNode {
 
-        @Child protected RubyStringLibrary libString = RubyStringLibrary.getFactory().createDispatched(2);
-        @Child protected RubyStringLibrary libPattern = RubyStringLibrary.getFactory().createDispatched(2);
+        @Child protected RubyStringLibrary libString = RubyStringLibrary.createDispatched();
+        @Child protected RubyStringLibrary libPattern = RubyStringLibrary.createDispatched();
         @Child NewSingleByteOptimizableNode singleByteOptimizableNode = NewSingleByteOptimizableNode.create();
 
         @Specialization(guards = "singleByteOptimizableNode.execute(string, stringEncoding)")
@@ -4248,11 +4248,10 @@ public abstract class StringNodes {
     @Primitive(name = "string_byte_index", lowerFixnum = 2)
     public abstract static class StringByteIndexNode extends PrimitiveArrayArgumentsNode {
 
-        @Child protected RubyStringLibrary libString = RubyStringLibrary.getFactory().createDispatched(2);
-        @Child protected RubyStringLibrary libPattern = RubyStringLibrary.getFactory().createDispatched(2);
-
         @Specialization
         protected Object stringByteIndex(Object rubyString, Object rubyPattern, int byteOffset,
+                @CachedLibrary(limit = "LIBSTRING_CACHE") RubyStringLibrary libString,
+                @CachedLibrary(limit = "LIBSTRING_CACHE") RubyStringLibrary libPattern,
                 @Cached TruffleString.ByteIndexOfStringNode byteIndexOfStringNode,
                 @Cached ConditionProfile indexOutOfBoundsProfile,
                 @Cached ConditionProfile foundProfile) {

--- a/src/main/java/org/truffleruby/core/string/StringNodes.java
+++ b/src/main/java/org/truffleruby/core/string/StringNodes.java
@@ -4314,8 +4314,7 @@ public abstract class StringNodes {
     @ImportStatic(StringGuards.class)
     public abstract static class StringByteCharacterIndexNode extends PrimitiveArrayArgumentsNode {
 
-        @Child SingleByteOptimizableNode singleByteOptimizableNode = SingleByteOptimizableNode
-                .create();
+        @Child NewSingleByteOptimizableNode singleByteOptimizableNode = NewSingleByteOptimizableNode.create();
 
         public abstract int executeStringByteCharacterIndex(Object string, int byteIndex);
 
@@ -4333,7 +4332,7 @@ public abstract class StringNodes {
 
         @Specialization(
                 guards = {
-                        "!isSingleByteOptimizable(libString.getRope(string), libString.getEncoding(string), singleByteOptimizableNode)",
+                        "!isSingleByteOptimizable(libString.getTString(string), libString.getEncoding(string), singleByteOptimizableNode)",
                         "isFixedWidthEncoding(libString.getRope(string))" })
         protected int fixedWidth(Object string, int byteIndex,
                 @CachedLibrary(limit = "LIBSTRING_CACHE") RubyStringLibrary libString) {
@@ -4342,7 +4341,7 @@ public abstract class StringNodes {
 
         @Specialization(
                 guards = {
-                        "!isSingleByteOptimizable(libString.getRope(string), libString.getEncoding(string), singleByteOptimizableNode)",
+                        "!isSingleByteOptimizable(libString.getTString(string), libString.getEncoding(string), singleByteOptimizableNode)",
                         "!isFixedWidthEncoding(libString.getRope(string))",
                         "isValidUtf8(libString.getRope(string), codeRangeNode)" })
         protected int validUtf8(Object string, int byteIndex,
@@ -4356,7 +4355,7 @@ public abstract class StringNodes {
         @TruffleBoundary
         @Specialization(
                 guards = {
-                        "!isSingleByteOptimizable(libString.getRope(string), libString.getEncoding(string), singleByteOptimizableNode)",
+                        "!isSingleByteOptimizable(libString.getTString(string), libString.getEncoding(string), singleByteOptimizableNode)",
                         "!isFixedWidthEncoding(libString.getRope(string))",
                         "!isValidUtf8(libString.getRope(string), codeRangeNode)" })
         protected int notValidUtf8(Object string, int byteIndex,

--- a/src/main/java/org/truffleruby/core/string/StringNodes.java
+++ b/src/main/java/org/truffleruby/core/string/StringNodes.java
@@ -4250,7 +4250,6 @@ public abstract class StringNodes {
 
         @Child protected RubyStringLibrary libString = RubyStringLibrary.getFactory().createDispatched(2);
         @Child protected RubyStringLibrary libPattern = RubyStringLibrary.getFactory().createDispatched(2);
-        @Child NewSingleByteOptimizableNode singleByteOptimizableNode = NewSingleByteOptimizableNode.create();
 
         @Specialization
         protected Object stringByteIndex(Object rubyString, Object rubyPattern, int byteOffset,

--- a/src/main/java/org/truffleruby/core/string/StringNodes.java
+++ b/src/main/java/org/truffleruby/core/string/StringNodes.java
@@ -1767,7 +1767,7 @@ public abstract class StringNodes {
                 guards = { "!isEmpty(string.rope)", "isSingleByteOptimizable(string, singleByteOptimizableNode)" })
         protected Object lstripBangSingleByte(RubyString string,
                 @Cached BytesNode bytesNode,
-                @Cached SingleByteOptimizableNode singleByteOptimizableNode,
+                @Cached NewSingleByteOptimizableNode singleByteOptimizableNode,
                 @Cached ConditionProfile noopProfile) {
             // Taken from org.jruby.RubyString#lstrip_bang19 and org.jruby.RubyString#singleByteLStrip.
 
@@ -1799,7 +1799,7 @@ public abstract class StringNodes {
         @Specialization(
                 guards = { "!isEmpty(string.rope)", "!isSingleByteOptimizable(string, singleByteOptimizableNode)" })
         protected Object lstripBang(RubyString string,
-                @Cached SingleByteOptimizableNode singleByteOptimizableNode,
+                @Cached NewSingleByteOptimizableNode singleByteOptimizableNode,
                 @Cached GetActualEncodingNode getActualEncodingNode,
                 @CachedLibrary(limit = "LIBSTRING_CACHE") RubyStringLibrary strings) {
             // Taken from org.jruby.RubyString#lstrip_bang19 and org.jruby.RubyString#multiByteLStrip.
@@ -2809,7 +2809,7 @@ public abstract class StringNodes {
                         "isSingleByteOptimizable(string, singleByteOptimizableNode)" })
         protected RubyString reverseSingleByteOptimizable(RubyString string,
                 @Cached BytesNode bytesNode,
-                @Cached SingleByteOptimizableNode singleByteOptimizableNode) {
+                @Cached NewSingleByteOptimizableNode singleByteOptimizableNode) {
             final Rope rope = string.rope;
             final byte[] originalBytes = bytesNode.execute(rope);
             final int len = originalBytes.length;
@@ -2830,7 +2830,7 @@ public abstract class StringNodes {
         protected RubyString reverse(RubyString string,
                 @Cached BytesNode bytesNode,
                 @Cached CodeRangeNode codeRangeNode,
-                @Cached SingleByteOptimizableNode singleByteOptimizableNode) {
+                @Cached NewSingleByteOptimizableNode singleByteOptimizableNode) {
             // Taken from org.jruby.RubyString#reverse!
 
             final Rope rope = string.rope;
@@ -3713,7 +3713,7 @@ public abstract class StringNodes {
         protected Object stringChrAtSingleByte(Object string, int byteIndex,
                 @CachedLibrary(limit = "LIBSTRING_CACHE") RubyStringLibrary strings,
                 @Cached StringByteSubstringPrimitiveNode stringByteSubstringNode,
-                @Cached SingleByteOptimizableNode singleByteOptimizableNode) {
+                @Cached NewSingleByteOptimizableNode singleByteOptimizableNode) {
             return stringByteSubstringNode.executeStringByteSubstring(string, byteIndex, 1);
         }
 
@@ -3727,7 +3727,7 @@ public abstract class StringNodes {
                 @Cached TruffleString.GetInternalByteArrayNode getInternalByteArrayNode,
                 @Cached CalculateCharacterLengthNode calculateCharacterLengthNode,
                 @Cached CodeRangeNode codeRangeNode,
-                @Cached SingleByteOptimizableNode singleByteOptimizableNode,
+                @Cached NewSingleByteOptimizableNode singleByteOptimizableNode,
                 @Cached TruffleString.SubstringByteIndexNode substringByteIndexNode,
                 @Cached TruffleString.ForceEncodingNode forceEncodingNode) {
             final Rope rope = strings.getRope(string);
@@ -3920,7 +3920,7 @@ public abstract class StringNodes {
                         "isSingleByteOptimizable(strings.getTString(string), strings.getEncoding(string), singleByteOptimizableNode)" })
         protected Object stringFindCharacterSingleByte(Object string, int offset,
                 @CachedLibrary(limit = "LIBSTRING_CACHE") RubyStringLibrary strings,
-                @Cached SingleByteOptimizableNode singleByteOptimizableNode,
+                @Cached NewSingleByteOptimizableNode singleByteOptimizableNode,
                 @Cached TruffleString.SubstringByteIndexNode substringNode) {
             // Taken from Rubinius's String::find_character.
             return createSubString(substringNode, strings, string, offset, 1);
@@ -3936,7 +3936,7 @@ public abstract class StringNodes {
                 @Cached GetBytesObjectNode getBytesObject,
                 @Cached CalculateCharacterLengthNode calculateCharacterLengthNode,
                 @Cached CodeRangeNode codeRangeNode,
-                @Cached SingleByteOptimizableNode singleByteOptimizableNode,
+                @Cached NewSingleByteOptimizableNode singleByteOptimizableNode,
                 @Cached TruffleString.SubstringByteIndexNode substringNode) {
             // Taken from Rubinius's String::find_character.
 
@@ -4699,7 +4699,7 @@ public abstract class StringNodes {
                 "isSingleByteOptimizable(strings.getTString(string), strings.getEncoding(string), singleByteOptimizableNode)" })
         protected int singleByteOptimizable(Object string, int index,
                 @CachedLibrary(limit = "LIBSTRING_CACHE") RubyStringLibrary strings,
-                @Cached SingleByteOptimizableNode singleByteOptimizableNode) {
+                @Cached NewSingleByteOptimizableNode singleByteOptimizableNode) {
             return index - 1;
         }
 
@@ -4709,7 +4709,7 @@ public abstract class StringNodes {
                 "isFixedWidthEncoding(strings.getRope(string))" })
         protected int fixedWidthEncoding(Object string, int index,
                 @CachedLibrary(limit = "LIBSTRING_CACHE") RubyStringLibrary strings,
-                @Cached SingleByteOptimizableNode singleByteOptimizableNode,
+                @Cached NewSingleByteOptimizableNode singleByteOptimizableNode,
                 @Cached ConditionProfile firstCharacterProfile) {
             final Encoding encoding = strings.getRope(string).getEncoding();
 
@@ -4732,7 +4732,7 @@ public abstract class StringNodes {
         @TruffleBoundary
         protected Object other(Object string, int index,
                 @CachedLibrary(limit = "LIBSTRING_CACHE") RubyStringLibrary strings,
-                @Cached SingleByteOptimizableNode singleByteOptimizableNode) {
+                @Cached NewSingleByteOptimizableNode singleByteOptimizableNode) {
             final Rope rope = strings.getRope(string);
             final int p = 0;
             final int end = p + rope.byteLength();

--- a/src/main/java/org/truffleruby/core/string/StringNodes.java
+++ b/src/main/java/org/truffleruby/core/string/StringNodes.java
@@ -954,8 +954,7 @@ public abstract class StringNodes {
 
         @Child private NegotiateCompatibleEncodingNode negotiateCompatibleEncodingNode = NegotiateCompatibleEncodingNode
                 .create();
-        @Child SingleByteOptimizableNode singleByteOptimizableNode = SingleByteOptimizableNode
-                .create();
+        @Child NewSingleByteOptimizableNode singleByteOptimizableNode = NewSingleByteOptimizableNode.create();
         private final ConditionProfile incompatibleEncodingProfile = ConditionProfile.create();
 
         @CreateCast("other")
@@ -964,7 +963,7 @@ public abstract class StringNodes {
         }
 
         @Specialization(
-                guards = "bothSingleByteOptimizable(strings.getRope(string), stringsOther.getRope(other), strings.getEncoding(string), stringsOther.getEncoding(other))")
+                guards = "bothSingleByteOptimizable(strings.getTString(string), stringsOther.getTString(other), strings.getEncoding(string), stringsOther.getEncoding(other))")
         protected Object caseCmpSingleByte(Object string, Object other,
                 @CachedLibrary(limit = "LIBSTRING_CACHE") RubyStringLibrary strings,
                 @CachedLibrary(limit = "LIBSTRING_CACHE") RubyStringLibrary stringsOther) {
@@ -979,7 +978,7 @@ public abstract class StringNodes {
         }
 
         @Specialization(
-                guards = "!bothSingleByteOptimizable(strings.getRope(string), stringsOther.getRope(other), strings.getEncoding(string), stringsOther.getEncoding(other))")
+                guards = "!bothSingleByteOptimizable(strings.getTString(string), stringsOther.getTString(other), strings.getEncoding(string), stringsOther.getEncoding(other))")
         protected Object caseCmp(Object string, Object other,
                 @CachedLibrary(limit = "LIBSTRING_CACHE") RubyStringLibrary strings,
                 @CachedLibrary(limit = "LIBSTRING_CACHE") RubyStringLibrary stringsOther) {
@@ -995,10 +994,11 @@ public abstract class StringNodes {
                     .multiByteCasecmp(encoding.jcoding, strings.getRope(string), stringsOther.getRope(other));
         }
 
-        protected boolean bothSingleByteOptimizable(Rope stringRope, Rope otherRope, RubyEncoding stringEncoding,
+        protected boolean bothSingleByteOptimizable(AbstractTruffleString string, AbstractTruffleString other,
+                RubyEncoding stringEncoding,
                 RubyEncoding otherEncoding) {
-            return singleByteOptimizableNode.execute(stringRope, stringEncoding) &&
-                    singleByteOptimizableNode.execute(otherRope, otherEncoding);
+            return singleByteOptimizableNode.execute(string, stringEncoding) &&
+                    singleByteOptimizableNode.execute(other, otherEncoding);
         }
     }
 

--- a/src/main/java/org/truffleruby/language/RubyBaseNode.java
+++ b/src/main/java/org/truffleruby/language/RubyBaseNode.java
@@ -198,6 +198,14 @@ public abstract class RubyBaseNode extends Node {
         return createString(substring, encoding);
     }
 
+    protected final RubyString createSubString(TruffleString.SubstringNode substringNode,
+            AbstractTruffleString tstring, RubyEncoding encoding, int codePointOffset, int codePointLength) {
+        final TruffleString substring = substringNode.execute(tstring, codePointOffset, codePointLength,
+                encoding.tencoding,
+                true);
+        return createString(substring, encoding);
+    }
+
     protected final CoreLibrary coreLibrary() {
         return getContext().getCoreLibrary();
     }

--- a/src/main/java/org/truffleruby/language/library/RubyStringLibrary.java
+++ b/src/main/java/org/truffleruby/language/library/RubyStringLibrary.java
@@ -15,14 +15,15 @@ import com.oracle.truffle.api.library.LibraryFactory;
 import com.oracle.truffle.api.strings.AbstractTruffleString;
 import org.truffleruby.core.encoding.RubyEncoding;
 import org.truffleruby.core.rope.Rope;
+import org.truffleruby.language.RubyBaseNode;
 
 @GenerateLibrary
 public abstract class RubyStringLibrary extends Library {
 
     private static final LibraryFactory<RubyStringLibrary> FACTORY = LibraryFactory.resolve(RubyStringLibrary.class);
 
-    public static LibraryFactory<RubyStringLibrary> getFactory() {
-        return FACTORY;
+    public static RubyStringLibrary createDispatched() {
+        return FACTORY.createDispatched(RubyBaseNode.LIBSTRING_CACHE);
     }
 
     public static RubyStringLibrary getUncached() {

--- a/src/main/ruby/truffleruby/core/truffle/string_operations.rb
+++ b/src/main/ruby/truffleruby/core/truffle/string_operations.rb
@@ -284,6 +284,7 @@ module Truffle
       end
     end
 
+    # MRI: rb_str_byteindex_m
     def self.byte_index(src, str, start=0)
       start += src.bytesize if start < 0
       if start < 0 or start > src.bytesize


### PR DESCRIPTION
This PR removes most usages of `RopeNodes.SingleByteOptimizableNode`. In the process, several of the string primitives were substantially rewritten to make use of new TruffleString nodes. Please note that I have not performed any performance analysis of these revised primitives. I focused only on functionality and simplifying things. In particular, some of the primitives are now a single specialization, letting TruffleString do all the heavy lifting. But, it may be beneficial for us to provide specializations for narrow cases that only apply to TruffleRuby (e.g., byte-based vs code-point based index ops with a `CR_7BIT` coderange). Part of the justification for collapsing to a single specialization was to improve interpreter performance by not repeating the same operations multiple times (e.g., getting a TruffleString from a RubyString and then getting its code point length).

Unfortunately, I wasn't able to completely remove usages of `RopeNodes.SingleByteOptimizableNode`. The last usage of the node comes from our format nodes, which were all written to work directly with ropes, relying on them to encapsulate the encoding. Converting these nodes to use TruffleString is non-trivial. I'll look at updating those nodes in another pass after this PR.