### PR TITLE
Make an empty hash shift return nil.

### DIFF
--- a/src/main/java/org/truffleruby/core/hash/HashNodes.java
+++ b/src/main/java/org/truffleruby/core/hash/HashNodes.java
@@ -511,9 +511,9 @@ public abstract class HashNodes {
     public abstract static class ShiftNode extends CoreMethodArrayArgumentsNode {
 
         @Specialization(guards = "hash.empty()")
-        protected Object shiftEmpty(RubyHash hash,
+        protected Nil shiftEmpty(RubyHash hash,
                 @Cached DispatchNode callDefault) {
-            return callDefault.call(hash, "default", nil);
+            return nil;
         }
 
         @Specialization(guards = "!hash.empty()", limit = "hashStrategyLimit()")


### PR DESCRIPTION
Ruby 3.2 empty Hash, when `#shift` is applied returns a `nil`. This PR makes this update for truffleruby.